### PR TITLE
Update simann_example.swift

### DIFF
--- a/Simulated annealing/simann_example.swift
+++ b/Simulated annealing/simann_example.swift
@@ -138,7 +138,7 @@ extension Tour {
   }
 
   func shuffle() {
-    self.shuffle()
+    self.tour.shuffle()
   }
 }
 


### PR DESCRIPTION
Corrected definition where shuffle() was invoking self.shuffle() instead of self.tour.shuffle(), which would left the example in a infinite loop of shuffle() invocation

<!-- Thanks for contributing to the SAC! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist

- [ ] I've looked at the [contribution guidelines](https://github.com/raywenderlich/swift-algorithm-club/blob/master/.github/CONTRIBUTING.md).
- [ ] This pull request is complete and ready for review.

### Description

<!-- In a short paragraph, describe the PR --> 

